### PR TITLE
Change URLs to new Github owner

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FrederikS/phantom-cheerio.git"
+    "url": "git+https://github.com/motortalk/phantom-cheerio.git"
   },
   "bugs": {
-    "url": "https://github.com/FrederikS/phantom-cheerio/issues"
+    "url": "https://github.com/motortalk/phantom-cheerio/issues"
   },
-  "homepage": "https://github.com/FrederikS/phantom-cheerio#readme",
+  "homepage": "https://github.com/motortalk/phantom-cheerio#readme",
   "dependencies": {
     "cheerio": "^0.19.0",
     "phantom": "^0.7.2",


### PR DESCRIPTION
The repository has been transferred to MOTOR-TALK's Github account. The URLs in NPM should also point to it.
